### PR TITLE
Bump nodejs version to 18.16.1-r0 under Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 FROM alpine:3.18.0 As production
 ENV NODE_ENV production
-RUN apk add --no-cache nodejs=18.16.0-r1 npm=9.6.6-r0 dumb-init=1.2.5-r2
+RUN apk add --no-cache nodejs=18.16.1-r0 npm=9.6.6-r0 dumb-init=1.2.5-r2
 COPY --chown=root:root --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=root:root --from=build /usr/src/app/dist ./dist
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -21,9 +21,17 @@ To run the project natively, you will need to have Node.js v18 or higher and npm
 To run the project with Docker, you will need to have Docker installed on your machine.
 
 1. 🍴 Clone this repository to your local machine.
-2. 🐳 Run `docker compose build` to build the containers.
-3. 🐳 Run `docker compose up` to start the containers.
-4. 🌍 The API will be available at `http://localhost:3000/`.
+2. 📝 Copy the .env.example file and rename it to .env. Open the .env file and specify the desired values for MONGODB_URI and PORT variables.
+For example:
+    ```
+    # The MongoDB connection string for the BlogPost database
+    MONGODB_URI="mongodb://mongodb/test"
+    # The port on which the Blog CMS API will run
+    PORT="3000"
+    ```
+3. 🐳 Run `docker compose build` to build the containers.
+4. 🐳 Run `docker compose up` to start the containers.
+5. 🌍 The API will be available at `http://localhost:3000/`.
 
 ## 📖 Usage
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     image: mongo:latest
     restart: always
 
-  api: 
+  api:
     build: .
     ports:
       - 3000:$PORT


### PR DESCRIPTION
Adds missing instructions in README for setting up environmental variables when using docker
Bumps nodejs version to 18.16.1-r0 since this is the current version that alpine has in its package manager repositories.
Removes a whitespace in docker-compose